### PR TITLE
🐛 Fix Coolify deployment - remove readme from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "tatis"
 version = "1.0.0"
 description = "Does Fernando Tatis Jr have an error today?"
-readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "Django",


### PR DESCRIPTION
## Summary

Fixes the Coolify/nixpacks deployment failure caused by the `readme = "README.md"` field in `pyproject.toml`.

## Problem

The previous PR (#357) introduced a build failure in Coolify. The error was:

```
OSError: Readme file does not exist: README.md
```

This happened because nixpacks copies only `pyproject.toml` during the install phase (before copying the rest of the code), so README.md wasn't available when pip tried to build the package.

## Solution

Removed the `readme` field from `pyproject.toml`. Since this Django app isn't being published to PyPI, the readme field isn't necessary.

## Test Plan

- [x] Package installs successfully locally with `uv pip install -e .`
- [x] Build should now succeed in Coolify (will verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)