### PR TITLE
⚡ Migrate from pre-commit to prek

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "freezegun",
     "gunicorn",
     "MLB-StatsAPI",
-    "pre-commit",
+    "prek",
     "psycopg[binary,pool]>=3.2.9",
     "pytest-cov",
     "pytest-django",


### PR DESCRIPTION
## Summary
- Replaced `pre-commit` dependency with `prek` in pyproject.toml
- Prek is a Rust-based drop-in replacement for pre-commit that's 10x faster
- Maintains full compatibility with existing `.pre-commit-config.yaml`
- All hooks tested and passing

## Benefits
- 10x performance improvement over pre-commit
- Uses half the disk space
- Zero configuration changes required
- Hooks run in parallel using uv for faster dependency management

## Test plan
- [x] Installed prek using `uv tool install prek`
- [x] Uninstalled pre-commit hooks and installed prek hooks
- [x] Ran `prek run --all-files` - all hooks passed
- [x] Git commit triggered prek hooks automatically - all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)