### PR TITLE
✨ Add Django Constance for runtime-editable configuration

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,31 +1,38 @@
 import pytest
-
-from content.models import InjuredList, SuspendedList
+from constance import config
 
 
 @pytest.fixture
 def not_on_injured_list():
-    InjuredList.objects.get_or_create(is_injured=False)
-    is_injured = InjuredList.objects.all()[0]
-    return is_injured
+    """Set IS_INJURED config to False for testing."""
+    original_value = config.IS_INJURED
+    config.IS_INJURED = False
+    yield config
+    config.IS_INJURED = original_value
 
 
 @pytest.fixture
 def on_injured_list():
-    InjuredList.objects.get_or_create(is_injured=True)
-    is_injured = InjuredList.objects.all()[0]
-    return is_injured
+    """Set IS_INJURED config to True for testing."""
+    original_value = config.IS_INJURED
+    config.IS_INJURED = True
+    yield config
+    config.IS_INJURED = original_value
 
 
 @pytest.fixture
 def not_suspended():
-    SuspendedList.objects.get_or_create(is_suspended=False)
-    is_suspended = SuspendedList.objects.all()[0]
-    return is_suspended
+    """Set IS_SUSPENDED config to False for testing."""
+    original_value = config.IS_SUSPENDED
+    config.IS_SUSPENDED = False
+    yield config
+    config.IS_SUSPENDED = original_value
 
 
 @pytest.fixture
 def suspended():
-    SuspendedList.objects.get_or_create(is_suspended=True)
-    is_suspended = SuspendedList.objects.all()[0]
-    return is_suspended
+    """Set IS_SUSPENDED config to True for testing."""
+    original_value = config.IS_SUSPENDED
+    config.IS_SUSPENDED = True
+    yield config
+    config.IS_SUSPENDED = original_value

--- a/content/tests/test_models.py
+++ b/content/tests/test_models.py
@@ -1,21 +1,38 @@
 import pytest
+from constance import config
 
 
 @pytest.mark.django_db
-def test_string_representation_employee_not_on_injured_list(not_on_injured_list):
-    assert str(not_on_injured_list) == "False"
+def test_constance_config_not_on_injured_list(not_on_injured_list):
+    """Test that IS_INJURED config can be set to False."""
+    assert config.IS_INJURED is False
 
 
 @pytest.mark.django_db
-def test_string_representation_employee_on_injured_list(on_injured_list):
-    assert str(on_injured_list) == "True"
+def test_constance_config_on_injured_list(on_injured_list):
+    """Test that IS_INJURED config can be set to True."""
+    assert config.IS_INJURED is True
 
 
 @pytest.mark.django_db
-def test_string_representation_player_not_suspended(not_suspended):
-    assert str(not_suspended) == "False"
+def test_constance_config_player_not_suspended(not_suspended):
+    """Test that IS_SUSPENDED config can be set to False."""
+    assert config.IS_SUSPENDED is False
 
 
 @pytest.mark.django_db
-def test_string_representation_player_suspended(suspended):
-    assert str(suspended) == "True"
+def test_constance_config_player_suspended(suspended):
+    """Test that IS_SUSPENDED config can be set to True."""
+    assert config.IS_SUSPENDED is True
+
+
+@pytest.mark.django_db
+def test_constance_config_defaults():
+    """Test that Constance config has correct default values."""
+    assert config.PLAYER_TEAM_ID == 135
+    assert config.PLAYER_LAST_NAME == "Tatis Jr"
+    assert config.COLOR_NO_ERROR == "#FFC425"
+    assert config.COLOR_ERROR == "#E35625"
+    assert config.MESSAGE_ERROR == "Yes"
+    assert config.MESSAGE_NO_ERROR == "Not Yet"
+    assert config.MESSAGE_NO_ERROR_INJURED == "Not Yet *"

--- a/content/tests/test_utils.py
+++ b/content/tests/test_utils.py
@@ -20,42 +20,52 @@ def test_get_game_id():
 
 @pytest.mark.django_db
 def test_check_for_error_returns_yes_for_tatisjr(not_on_injured_list):
+    from constance import config
+
     game_id = get_game_id(135, datetime.date(2021, 4, 24))
     error = check_for_error(game_id, "Tatis")
-    assert error[0] == "Yes"
-    assert error[1] == "#E35625"
+    assert error[0] == config.MESSAGE_ERROR
+    assert error[1] == config.COLOR_ERROR
 
 
 @pytest.mark.django_db
 def test_check_for_error_returns_no_for_tatisjr_not_on_il(not_on_injured_list):
+    from constance import config
+
     game_id = get_game_id(135, datetime.date(2021, 5, 1))
     error = check_for_error(game_id, "Tatis")
-    assert error[0] == "Not Yet"
-    assert error[1] == "#FFC425"
+    assert error[0] == config.MESSAGE_NO_ERROR
+    assert error[1] == config.COLOR_NO_ERROR
 
 
 @pytest.mark.django_db
 def test_check_for_padres_game_not_on_il(not_on_injured_list):
+    from constance import config
+
     game_id = get_game_id(135, datetime.date(2021, 5, 6))
     error = check_for_error(game_id, "Tatis")
-    assert error[0] == "Not Yet"
-    assert error[1] == "#FFC425"
+    assert error[0] == config.MESSAGE_NO_ERROR
+    assert error[1] == config.COLOR_NO_ERROR
 
 
 @pytest.mark.django_db
 def test_check_for_error_returns_no_for_tatisjr_on_il(on_injured_list):
+    from constance import config
+
     game_id = get_game_id(135, datetime.date(2021, 5, 1))
     error = check_for_error(game_id, "Tatis")
-    assert error[0] == "Not Yet *"
-    assert error[1] == "#FFC425"
+    assert error[0] == config.MESSAGE_NO_ERROR_INJURED
+    assert error[1] == config.COLOR_NO_ERROR
 
 
 @pytest.mark.django_db
 def test_check_for_padres_game_on_il(on_injured_list):
+    from constance import config
+
     game_id = get_game_id(135, datetime.date(2021, 5, 6))
     error = check_for_error(game_id, "Tatis")
-    assert error[0] == "Not Yet *"
-    assert error[1] == "#FFC425"
+    assert error[0] == config.MESSAGE_NO_ERROR_INJURED
+    assert error[1] == config.COLOR_NO_ERROR
 
 
 @freeze_time("2022-12-31")

--- a/content/utils.py
+++ b/content/utils.py
@@ -2,8 +2,7 @@ import datetime
 
 import requests
 import statsapi
-
-from .models import InjuredList
+from constance import config
 
 
 def check_home_or_away(game_id: int, team_id: int):
@@ -18,16 +17,15 @@ def check_home_or_away(game_id: int, team_id: int):
 
 
 def check_for_error(game_id: int, player_last_name: str):
-    is_injured = InjuredList.objects.last()
-    if is_injured.is_injured:
-        did_an_error_happen = "Not Yet *"
+    if config.IS_INJURED:
+        did_an_error_happen = config.MESSAGE_NO_ERROR_INJURED
     else:
-        did_an_error_happen = "Not Yet"
-    display_color = "#FFC425"
+        did_an_error_happen = config.MESSAGE_NO_ERROR
+    display_color = config.COLOR_NO_ERROR
     url = f"https://statsapi.mlb.com/api/v1.1/game/{game_id}/feed/live"
     response = requests.get(url)
     game = response.json()
-    team_location = check_home_or_away(game_id, 135)
+    team_location = check_home_or_away(game_id, config.PLAYER_TEAM_ID)
 
     try:
         info = game.get("liveData").get("boxscore").get("teams").get(team_location).get("info")
@@ -39,8 +37,8 @@ def check_for_error(game_id: int, player_last_name: str):
                         errors = item.get("value").split("; ")
                         for error in errors:
                             if player_last_name in error:
-                                did_an_error_happen = "Yes"
-                                display_color = "#E35625"
+                                did_an_error_happen = config.MESSAGE_ERROR
+                                display_color = config.COLOR_ERROR
     except AttributeError:
         pass
     return did_an_error_happen, display_color

--- a/content/views.py
+++ b/content/views.py
@@ -1,8 +1,8 @@
 import datetime
 
+from constance import config
 from django.views.generic import TemplateView
 
-from .models import InjuredList, SuspendedList
 from .utils import check_for_error, get_game_id
 
 
@@ -13,11 +13,9 @@ class HomePageTemplateView(TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data()
         today = datetime.date.today()
-        game_id = get_game_id(135, today)
-        is_injured = InjuredList.objects.get_or_create(pk=1)[0]
-        is_suspended = SuspendedList.objects.get_or_create(pk=1)[0]
-        context["error"] = check_for_error(game_id, "Tatis Jr")[0]
-        context["color"] = check_for_error(game_id, "Tatis Jr")[1]
-        context["is_injured"] = is_injured.is_injured
-        context["is_suspended"] = is_suspended.is_suspended
+        game_id = get_game_id(config.PLAYER_TEAM_ID, today)
+        context["error"] = check_for_error(game_id, config.PLAYER_LAST_NAME)[0]
+        context["color"] = check_for_error(game_id, config.PLAYER_LAST_NAME)[1]
+        context["is_injured"] = config.IS_INJURED
+        context["is_suspended"] = config.IS_SUSPENDED
         return context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Does Fernando Tatis Jr have an error today?"
 requires-python = ">=3.13"
 dependencies = [
     "Django",
+    "django-constance[database]",
     "django-csp",
     "django-environ",
     "django-extensions",

--- a/tatisjr/settings.py
+++ b/tatisjr/settings.py
@@ -51,6 +51,8 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     # third party
+    "constance",
+    "constance.backends.database",
     "django_extensions",
     "health_check",
     "health_check.db",
@@ -198,5 +200,35 @@ LOGGING = {
             "handlers": ["null"],
             "propagate": False,
         },
+    },
+}
+
+# Django Constance Configuration
+CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
+
+CONSTANCE_CONFIG = {
+    "PLAYER_TEAM_ID": (135, "MLB Team ID for the player being tracked (135 = San Diego Padres)", int),
+    "PLAYER_LAST_NAME": ("Tatis Jr", "Last name of the player being tracked", str),
+    "COLOR_NO_ERROR": ("#FFC425", "Background color when player has no errors (hex color code)", str),
+    "COLOR_ERROR": ("#E35625", "Background color when player has an error (hex color code)", str),
+    "MESSAGE_ERROR": ("Yes", "Message displayed when player has an error", str),
+    "MESSAGE_NO_ERROR": ("Not Yet", "Message displayed when player has no errors", str),
+    "MESSAGE_NO_ERROR_INJURED": ("Not Yet *", "Message displayed when player has no errors and is injured", str),
+    "IS_INJURED": (False, "Whether the player is currently on the injured list", bool),
+    "IS_SUSPENDED": (False, "Whether the player is currently suspended", bool),
+}
+
+CONSTANCE_CONFIG_FIELDSETS = {
+    "Player Settings": {
+        "fields": ("PLAYER_TEAM_ID", "PLAYER_LAST_NAME", "IS_INJURED", "IS_SUSPENDED"),
+        "collapse": False,
+    },
+    "Display Settings": {
+        "fields": ("COLOR_NO_ERROR", "COLOR_ERROR"),
+        "collapse": False,
+    },
+    "Message Settings": {
+        "fields": ("MESSAGE_ERROR", "MESSAGE_NO_ERROR", "MESSAGE_NO_ERROR_INJURED"),
+        "collapse": False,
     },
 }


### PR DESCRIPTION
Replace hardcoded values and database models with Django Constance to enable runtime-editable configuration without code changes.

Changes:
- Add django-constance to dependencies in pyproject.toml
- Configure Constance with database backend in settings.py
- Replace InjuredList and SuspendedList models with Constance config
- Migrate hardcoded values (team ID, player name, colors, messages) to Constance
- Update views.py to use config.PLAYER_TEAM_ID and config.PLAYER_LAST_NAME
- Update utils.py to use Constance for all display values
- Update test fixtures to use Constance instead of models
- Update test assertions to use dynamic Constance values

Benefits:
- Settings now editable via Django admin at /admin/constance/config/
- No code changes or deployments needed to update player, colors, or messages
- All configuration organized in logical fieldsets (Player, Display, Messages)
- Maintains backward compatibility with existing functionality

Fixes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)