### PR TITLE
Update Dependabot configuration for Python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
   # Update Python dependencies weekly
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      day: "friday"
       time: "09:00"
     open-pull-requests-limit: 10
     groups:


### PR DESCRIPTION
Changed the package ecosystem from 'pip' to 'uv' and updated the schedule to monthly on Fridays.